### PR TITLE
Settings Page - Remove Award Banner

### DIFF
--- a/changelog/index.html
+++ b/changelog/index.html
@@ -9,9 +9,6 @@
       <h1>What's New</h1>
       <h2>We did a lot to make this new version amazing.</h2>
     </div>
-    <a href="/extras/awards/index.html">
-      <img src="/extras/awards/banner.svg" style="width: 70%; border-radius: .5rem;">
-    </a>
     <h1>Here are some of the features we've added/upgraded</h1>
     <div class="new-features">
       <div class="new-features-full"></div>

--- a/extras/index.html
+++ b/extras/index.html
@@ -82,9 +82,6 @@
         </div>
       </div>
       <div class="sectionwrap">
-        <a href="/extras/awards/index.html">
-          <img src="/extras/awards/banner.svg" style="width: 100%; border-radius: .5rem;">
-        </a>
         <div
           class="suggested"
           style="color: var(--primary-color); display: none"


### PR DESCRIPTION
Removes the award banner from the ScratchTools settings page